### PR TITLE
Catch error if no JSON body

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,11 @@ function Imgflipper(username, password) {
 					cb(err);
 				}
 				else {
-					body = JSON.parse(body);
+					try {
+						body = JSON.parse(body);
+					} catch (err) {
+						return cb(new Error('Imgflip did not return a json body'));
+					}
 
 					if (!body.success) {
 						cb(new Error(body.error_message));


### PR DESCRIPTION
## Overview

Imgflipper doesn't always return with a JSON body and instead an HTML error. This PR catches that and returns an error instance instead.
